### PR TITLE
orientation change and thread handling for wiring up

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizer.java
@@ -112,7 +112,7 @@ public class FocusVisualizer {
     this.tabStopCount = 0;
     this.focusElementHighlights.clear();
     this.focusElementLines.clear();
-//    this.setDrawItemsAndRedraw();
+    this.setDrawItemsAndRedraw();
   }
 
   private void setDrawItemsAndRedraw() {

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerController.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerController.java
@@ -1,30 +1,20 @@
 package com.microsoft.accessibilityinsightsforandroidservice;
 
-import android.view.WindowManager;
+import android.os.Handler;
+import android.os.Looper;
 import android.view.accessibility.AccessibilityEvent;
-
-import java.util.function.Supplier;
 
 public class FocusVisualizerController {
     private FocusVisualizer focusVisualizer;
     private FocusVisualizationStateManager focusVisualizationStateManager;
-    private AccessibilityEvent lastEvent;
-    private WindowManager windowManager;
-    private Supplier<WindowManager.LayoutParams>  layoutParamGenerator;
-    private FocusVisualizationCanvas focusVisualizationCanvas;
 
-    public FocusVisualizerController(FocusVisualizer focusVisualizer, FocusVisualizationStateManager focusVisualizationStateManager, WindowManager windowManager, Supplier<WindowManager.LayoutParams> layoutParamGenerator, FocusVisualizationCanvas focusVisualizationCanvas) {
+    public FocusVisualizerController(FocusVisualizer focusVisualizer, FocusVisualizationStateManager focusVisualizationStateManager) {
         this.focusVisualizer = focusVisualizer;
         this.focusVisualizationStateManager = focusVisualizationStateManager;
-        this.windowManager = windowManager;
-        this.layoutParamGenerator = layoutParamGenerator;
-        this.focusVisualizationCanvas = focusVisualizationCanvas;
         this.focusVisualizationStateManager.subscribe(this::onFocusVisualizationStateChange);
     }
 
     public void onFocusEvent(AccessibilityEvent event) {
-        lastEvent = event;
-
         if (focusVisualizationStateManager.getState() == false) {
             return;
         }
@@ -33,7 +23,6 @@ public class FocusVisualizerController {
     }
 
     public void onRedrawEvent(AccessibilityEvent event) {
-        lastEvent = event;
 
         if (focusVisualizationStateManager.getState() == false) {
             return;
@@ -42,12 +31,16 @@ public class FocusVisualizerController {
         focusVisualizer.HandleAccessibilityRedrawEvent(event);
     }
 
+    public void onOrientationChange(){
+        focusVisualizer.resetVisualizations();
+    }
+
     private void onFocusVisualizationStateChange(boolean newState) {
         if (newState) {
-//            focusVisualizer.HandleAccessibilityFocusEvent(lastEvent);
+            return;
         }
         else {
-            focusVisualizer.resetVisualizations();
+            new Handler(Looper.getMainLooper()).post(() -> focusVisualizer.resetVisualizations());
         }
     }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerControllerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerControllerTest.java
@@ -1,0 +1,117 @@
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+import android.view.accessibility.AccessibilityEvent;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Looper.class, FocusVisualizerController.class})
+public class FocusVisualizerControllerTest {
+
+    private final static ScheduledExecutorService mainThread = Executors.newSingleThreadScheduledExecutor();
+    @Mock FocusVisualizer focusVisualizerMock;
+    @Mock FocusVisualizationStateManager focusVisualizationStateManagerMock;
+    @Mock AccessibilityEvent accessibilityEventMock;
+    @Mock Looper looperMock;
+    @Mock Handler handlerMock;
+
+    FocusVisualizerController testSubject;
+
+    @Before
+    public void prepare() {
+        testSubject = new FocusVisualizerController(focusVisualizerMock, focusVisualizationStateManagerMock);
+    }
+
+    @Test
+    public void exists() {
+        Assert.assertNotNull(testSubject);
+    }
+
+    @Test
+    public void onFocusEventDoesNotCallVisualizerIfStateIsFalse(){
+        when(focusVisualizationStateManagerMock.getState()).thenReturn(false);
+        testSubject.onFocusEvent(accessibilityEventMock);
+        verify(focusVisualizerMock, times(0)).HandleAccessibilityFocusEvent(any(AccessibilityEvent.class));
+    }
+
+    @Test
+    public void onFocusEventCallsVisualizerIfStateIsTrue(){
+        when(focusVisualizationStateManagerMock.getState()).thenReturn(true);
+        testSubject.onFocusEvent(accessibilityEventMock);
+        verify(focusVisualizerMock, times(1)).HandleAccessibilityFocusEvent(any(AccessibilityEvent.class));
+    }
+
+    @Test
+    public void onRedrawEventDoesNotCallVisualizerIfStateIsFalse(){
+        when(focusVisualizationStateManagerMock.getState()).thenReturn(false);
+        testSubject.onRedrawEvent(accessibilityEventMock);
+        verify(focusVisualizerMock, times(0)).HandleAccessibilityRedrawEvent(any(AccessibilityEvent.class));
+    }
+
+    @Test
+    public void onRedrawEventCallsVisualizerIfStateIsTrue(){
+        when(focusVisualizationStateManagerMock.getState()).thenReturn(true);
+        testSubject.onRedrawEvent(accessibilityEventMock);
+        verify(focusVisualizerMock, times(1)).HandleAccessibilityRedrawEvent(any(AccessibilityEvent.class));
+    }
+
+    @Test
+    public void onOrientationChangeCallsResetVisualizations(){
+        testSubject.onOrientationChange();
+        verify(focusVisualizerMock, times(1)).resetVisualizations();
+    }
+
+
+    @Test
+    public void onFocusVisualizationStateChangeDoesNotResetVisualizationsIfStateIsTrue() throws Exception {
+        PowerMockito.mockStatic(Looper.class);
+        when(Looper.getMainLooper()).thenReturn(looperMock);
+        whenNew(Handler.class).withArguments(looperMock).thenReturn(handlerMock);
+
+        Answer<Boolean> handlerPostAnswer = new Answer<Boolean>() {
+            @Override
+            public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                Runnable runnable = invocation.getArgument(0, Runnable.class);
+                Long delay = 0L;
+                if (invocation.getArguments().length > 1) {
+                    delay = invocation.getArgument(1, Long.class);
+                }
+                if (runnable != null) {
+                    mainThread.schedule(runnable, delay, TimeUnit.MILLISECONDS);
+                }
+                return true;
+            }
+        };
+
+        doAnswer(handlerPostAnswer).when(handlerMock).post(any(Runnable.class));
+
+        Whitebox.invokeMethod(testSubject, "onFocusVisualizationStateChange", false);
+        verify(focusVisualizerMock, times(1)).resetVisualizations();
+    }
+
+
+}

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerControllerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerControllerTest.java
@@ -87,7 +87,7 @@ public class FocusVisualizerControllerTest {
 
 
     @Test
-    public void onFocusVisualizationStateChangeDoesNotResetVisualizationsIfStateIsTrue() throws Exception {
+    public void onFocusVisualizationStateChangeDoesResetsVisualizationsIfStateIsFalse() throws Exception {
         PowerMockito.mockStatic(Looper.class);
         when(Looper.getMainLooper()).thenReturn(looperMock);
         whenNew(Handler.class).withArguments(looperMock).thenReturn(handlerMock);


### PR DESCRIPTION
#### Description of changes

Added handling of configuration change, as well as some issues with threading.  Threads can only touch views that were created by them, so I had to add in a looper handler to ensure that the main thread did the reset of visualizations from `FocusVisualizerController.onFocusVisualizationStateChange` since that was being called inside of the Response thread.

